### PR TITLE
Use consistent import alias

### DIFF
--- a/content/docs/reference/documents/text.md
+++ b/content/docs/reference/documents/text.md
@@ -57,7 +57,7 @@ input.oninput = (e) => {
         // @ts-ignore
         const newValue: string = e.target.value
         console.log("newValue", newValue)
-        am.updateText(doc, ["text"], newValue)
+        Automerge.updateText(doc, ["text"], newValue)
     })
 }
 


### PR DESCRIPTION
The previous code example in this section says:

```
import * as Automerge from "@automerge/automerge"

```

but then second code example has:
```
am.updateText(...)
```

This is an unexpected alias change, so I'm changing it to say `Automerge.updateText`, like in other examples.