### PR TITLE
Some minor doc fixes

### DIFF
--- a/content/docs/cookbook/rich-text-prosemirror-react.md
+++ b/content/docs/cookbook/rich-text-prosemirror-react.md
@@ -26,7 +26,7 @@ Now, the app created by `@automerge/vite-app` creates a document which contains 
 ...
 let handle
 if (isValidAutomergeUrl(rootDocUrl)) {
-  handle = repo.find(rootDocUrl)
+  handle = await repo.find(rootDocUrl)
 } else {
   handle = repo.create({text: ""})
 }

--- a/content/docs/cookbook/rich-text-prosemirror-vanilla.md
+++ b/content/docs/cookbook/rich-text-prosemirror-vanilla.md
@@ -43,13 +43,11 @@ Now, we'll store the automerge URL for the document we are editing in the browse
 // a new document and update the URL fragment to match.
 const docUrl = window.location.hash.slice(1)
 if (docUrl && isValidAutomergeUrl(docUrl)) {
-  handle = repo.find(docUrl)
+  handle = await repo.find(docUrl)
 } else {
   handle = repo.create({ text: "" })
   window.location.hash = handle.url
 }
-// Wait for the handle to be available
-await handle.whenReady()
 ```
 
 At this point we have a document handle with a fully loaded automerge document, now we need to wire up a prosemirror editor.

--- a/content/docs/reference/library-initialization.md
+++ b/content/docs/reference/library-initialization.md
@@ -119,8 +119,8 @@ export default async function (req: Request): Promise<Response> {
   const repo = new Repo({
     network: [new BrowserWebSocketClientAdapter("wss://sync.automerge.org")],
   });
-  const handle = repo.find(docId);
-  const contents = await handle.doc();
+  const handle = await repo.find(docId);
+  const contents = handle.doc();
   return Response.json(contents);
 }
 ```
@@ -129,7 +129,7 @@ export default async function (req: Request): Promise<Response> {
 
 If you're in an environment which doesn't support importing WebAssembly modules as ES modules then you need to initialize the WebAssembly manually. There are two parts to this:
 
-- Change all imports in your application of `@automerge/automerge` and `@automerge/automerge-repo` to the "slim" variants (`@automerge/automerge/slim` and `@automerge/automerge-repo/slim)`
+- Change all imports in your application of `@automerge/automerge` and `@automerge/automerge-repo` to the "slim" variants (`@automerge/automerge/slim` and `@automerge/automerge-repo/slim`)
 - Obtain the WebAssembly module and initialize it manually, then wait for initialization to complete.
 
 For this latter part we expose two exports from the `@automerge/automerge` package which can be used to obtain the raw WebAssembly. `@automerge/automerge/automerge.wasm` is a binary version of the WebAssembly file, whilst `@automerge/automerge/automerge.wasm.base64.js` is a JS modules with a single export called `automergeWasmBase64` which is a base64 encoded version of the WebAssembly file.

--- a/content/docs/reference/repositories/ephemeral.md
+++ b/content/docs/reference/repositories/ephemeral.md
@@ -10,7 +10,7 @@ Ephemeral data is associated with a particular document, which means you need to
 ## Sending
 
 ```typescript
-const handle = Repo.find("<some url>");
+const handle = await repo.find("<some url>");
 handle.broadcast({
   some: "message",
 });
@@ -23,7 +23,7 @@ The object passed to `broadcast` will be CBOR encoded so you can send whatever y
 To receive you listen to the `"ephemeral-message"` event on the `DocHandle`
 
 ```typescript
-const handle = Repo.find("<some url>")
+const handle = await repo.find("<some url>")
 handle.on("ephemeral-message", (message: any) => {
     console.log("got an ephemeral message: ", message)
 })


### PR DESCRIPTION
 - use await with repo.find
 - drop DocHandle.whenReady() and replace DocHandle.docSync() calls with
   DocHandle.doc() since they are now obsolete
 - fix a stray paren

This does _not_ change dochandles.md since that requires some more
substantial updates since we made Repo.find async.
