### PR TITLE
Add logic and CSS styling for `highlight-red-start` and `highlight-red-end` inline code markup.

### DIFF
--- a/content/static/base.css
+++ b/content/static/base.css
@@ -427,6 +427,10 @@ pre code > * {
   background: #00f1;
 }
 
+.highlighted-red-line {
+  background: light-dark(#ffeef0, #3d1c1c);
+}
+
 :not(pre) > code {
   border: 1px solid var(--stark-shadow);
   padding: .1em .2em 0em;

--- a/system/markdown.ts
+++ b/system/markdown.ts
@@ -34,16 +34,25 @@ Markdown.renderer.rules.fence = (tokens, idx) => {
   // Process line highlight markers
   let lines = token.content.trim().split("\n")
   const highlightedLines = new Set<number>()
+  const highlightedRedLines = new Set<number>()
   let insideBlock = false
+  let insideRedBlock = false
   let highlightNext = false
   let out: string[] = []
   lines.forEach((line, i) => {
     if (/highlight-next-line/.test(line)) {
       highlightNext = true
+    } else if (/highlight-red-start/.test(line)) {
+      insideRedBlock = true
+    } else if (/highlight-red-end/.test(line)) {
+      insideRedBlock = false
     } else if (/highlight-start/.test(line)) {
       insideBlock = true
     } else if (/highlight-end/.test(line)) {
       insideBlock = false
+    } else if (insideRedBlock) {
+      highlightedRedLines.add(out.length)
+      out.push(line)
     } else if (insideBlock || highlightNext) {
       highlightNext = false
       highlightedLines.add(out.length)
@@ -66,6 +75,7 @@ Markdown.renderer.rules.fence = (tokens, idx) => {
   lines = highlightedBlock.split("\n").map((line, i) => {
     const classes = ["code-line"]
     if (highlightedLines.has(i)) classes.push("highlighted-line")
+    if (highlightedRedLines.has(i)) classes.push("highlighted-red-line")
     return `<div class="${classes.join(" ")}">${line}</div>`
   })
   lines = [`<pre><code class="language-${langName}">`, ...lines, "</code></pre>"]


### PR DESCRIPTION
While working through the tutorial, I observed some inline code markup for `highlight-red-start` but it was not rendering. This PR adds the logic to do that.

Example of current site:

<img width="2296" height="1830" alt="Screenshot 2026-05-27 at 10-36-06 Multiple Task Lists" src="https://github.com/user-attachments/assets/782f82ae-0e17-48b0-afcf-813d26aa9c86" />

Example of fix:

<img width="2420" height="1830" alt="Screenshot 2026-05-27 at 10-35-03 Multiple Task Lists" src="https://github.com/user-attachments/assets/d9641201-ba40-47ec-84cb-62bd448cc717" />
<img width="2420" height="1830" alt="Screenshot 2026-05-27 at 10-35-19 Persisting the Root Document" src="https://github.com/user-attachments/assets/bc764686-611c-4ae2-a1cb-57eaeb96777c" />
<img width="2342" height="1830" alt="Screenshot 2026-05-27 at 10-41-35 Multiple Task Lists" src="https://github.com/user-attachments/assets/a30cc780-cfba-4672-b4d2-600431abf92e" />
